### PR TITLE
Update 'What I Do' cards to highlight Go and Kubernetes

### DIFF
--- a/src/components/service/ServiceItems.js
+++ b/src/components/service/ServiceItems.js
@@ -4,17 +4,17 @@ import { useContext } from "react";
 const services = [
   {
     id: 1,
-    name: "Develop User Interfaces",
+    name: "Build Go Services",
     text: [
-      "I have the skills to design and develop visually appealing and user-friendly interfaces for websites and applications. I use my expertise in HTML, CSS, and JavaScript to structure and style frontend components, ensuring an attractive and intuitive user experience."
+      "I design and build reliable backend services using Go, focusing on clean APIs, efficient concurrency, and maintainable codebases that are ready for production workloads."
       ],
     image: "assets/img/news/1.jpg",
   },
   {
     id: 2,
-    name: "Implement Responsive Design",
+    name: "Kubernetes & Microservices Integration",
     text: [
-      "I excel in implementing responsive design techniques to make websites and applications seamlessly adapt to different devices and screen sizes. I ensure that the interface remains consistent and user-friendly across desktops, tablets, and mobile devices."
+      "I deploy and manage services on Kubernetes, connect microservices with well-defined contracts, and set up reliable service communication, scaling, and observability."
        ],
     image: "assets/img/news/2.jpg",
   },


### PR DESCRIPTION
### Motivation
- Replace two frontend-centric service cards with backend and infrastructure skills to match requested content about Go and Kubernetes/microservices.
- Surface Go service development and Kubernetes-based microservices integration in the first boxes of the Services page.

### Description
- Update `src/components/service/ServiceItems.js` to change service `id: 1` name to `Build Go Services` and replace its description with Go backend-focused copy.
- Update `src/components/service/ServiceItems.js` to change service `id: 2` name to `Kubernetes & Microservices Integration` and replace its description with Kubernetes/microservices-focused copy.
- This is a content-only change and no UI components or behavior were modified beyond the text labels.

### Testing
- Started the dev server with `npm run dev` and Next.js compiled client and server successfully.
- Executed a Playwright script that navigated to the Services section and saved `artifacts/service-section.png` as a visual verification.
- No unit tests or CI jobs were run for this content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d40c1ef8832cbeb2fe50ea21a936)