### PR TITLE
Update About intro, skills list, and copyright year

### DIFF
--- a/src/components/about/Intro.js
+++ b/src/components/about/Intro.js
@@ -11,24 +11,42 @@ const Intro = () => {
       </div>
       <div className="about_text w-full h-auto clear-both float-left border-solid border-[#DFDFDF] border-b pb-[31px] mb-[30px]">
         <p className="mb-[11px]">
-        Greetings! My name is Mamdouh, and I am a web developer with expertise in HTML, CSS, JavaScript, and React. With a strong background in building websites, I have successfully worked as a freelancer on platforms like Upwork, delivering exceptional websites that help clients solve their problems and achieve their goals.
+          I’m Mamdouh Elsheshtawy, a London-based Full-Stack Engineer with a
+          strong passion for crafting clean, user-focused digital experiences.
+          My journey began in front-end development, where I built responsive,
+          modern interfaces, and has since evolved into full-stack engineering—
+          allowing me to design, build, and scale complete web applications from
+          the ground up.
+        </p>
+        <p className="mb-[11px]">
+          Over the years, I’ve gained hands-on experience working across the
+          entire stack, combining intuitive user interfaces with robust,
+          high-performance back-end systems. I work both as a freelancer and
+          within collaborative teams, helping businesses and individuals
+          transform ideas into reliable, production-ready digital products.
+        </p>
+        <p className="mb-[11px]">
+          I specialise in building performant, maintainable applications using
+          modern technologies. On the front end, I focus on clean architecture,
+          accessibility, and seamless user experiences. On the back end, I work
+          extensively with Go, designing efficient services and APIs,
+          containerising applications with Docker, and deploying and scaling
+          them using Kubernetes. This allows me to deliver solutions that are
+          not only visually engaging, but also resilient, scalable, and ready
+          for real-world traffic.
         </p>
         <p>
-        I take pride in my ability to transform ideas into fully functional platforms. From concept to completion, I am dedicated to creating websites with a unique, outstanding, and contemporary look and feel. I go above and beyond to ensure that the websites I build are not only visually appealing but also optimised for performance and longevity.
-        With my in-depth understanding of web mechanics, I excel at integrating complex functionalities that require minimal maintenance. The websites I develop have the capability to run seamlessly for years, providing clients with a hassle free experience.
-        I am passionate about delivering high quality solutions that exceed client expectations. 
+          I’ve worked with clients across diverse industries, delivering
+          projects that solve real problems and create measurable impact.
+          Whether it’s launching a new product, improving performance, or
+          architecting a scalable system, I take pride in building solutions
+          that meet high technical standards and exceed expectations.
         </p>
       </div>
       <div className="tokyo_tm_short_info w-full h-auto clear-both float-left flex mb-[40px]">
         <div className="left w-1/2 pr-[50px]">
           <div className="tokyo_tm_info w-full h-auto clear-both float-left">
             <ul className="m-0 list-none">
-              <li className="m-0">
-                <span className="min-w-[100px] float-left mr-[10px] font-bold text-black">
-                  Birthday:
-                </span>
-                <span>24.03.1989</span>
-              </li>
               <li className="m-0">
                 <span className="min-w-[100px] float-left mr-[10px] font-bold text-black">
                   Age:
@@ -77,12 +95,6 @@ const Intro = () => {
                   Interest:
                 </span>
                 <span>Playing Basketball</span>
-              </li>
-              <li className="m-0">
-                <span className="min-w-[100px] float-left mr-[10px] font-bold text-black">
-                  Freelance:
-                </span>
-                <span>Available</span>
               </li>
             </ul>
           </div>

--- a/src/components/about/Skills.js
+++ b/src/components/about/Skills.js
@@ -2,11 +2,13 @@ const programming = [
   { id: 1, name: "HTML", value: 85 },
   { id: 2, name: "CSS", value: 80 },
   { id: 3, name: "JavaScript", value: 80 },
-  { id: 4, name: "React", value: 70 },
-  { id: 6, name: "Tailwind CSS", value: 80 },
-  { id: 5, name: "BootStrap", value: 75 },
-  { id: 6, name: "TypeScript", value: 75 },
-  { id: 7, name: "Final Cut Pro", value: 90 },
+  { id: 4, name: "Next Js", value: 70 },
+  { id: 5, name: "Tailwind CSS", value: 80 },
+  { id: 6, name: "Go (Golang)", value: 80 },
+  { id: 7, name: "TypeScript", value: 75 },
+  { id: 8, name: "Docker", value: 70 },
+  { id: 9, name: "Kubernetes", value: 60 },
+  { id: 10, name: "Final Cut Pro", value: 90 },
 ];
 const language = [
   { id: 1, name: "English", value: 100 },

--- a/src/layout/Sidebar.js
+++ b/src/layout/Sidebar.js
@@ -41,7 +41,7 @@ const Sidebar = () => {
         </div>
         <div className="copyright w-full float-left">
           <p className="text-[15px] text-[#999] font-montserrat leading-[25px]">
-            © {new Date().getFullYear()} Mamdouh
+            © 2026 Mamdouh
             <br />
             Created by{" "}
             <a


### PR DESCRIPTION
### Motivation
- Refresh the personal bio to present a professional Full-Stack Engineer summary and remove overly personal/availability fields from the short info list.  
- Replace the programming skills to reflect the provided technologies and correct sequential ids.  
- Ensure the sidebar shows the requested fixed copyright year.  

### Description
- Replaced the About copy in `src/components/about/Intro.js` with a multi-paragraph Full-Stack Engineer bio and removed the `Birthday` and `Freelance` list items.  
- Reworked the programming skills array in `src/components/about/Skills.js` to include `HTML`, `CSS`, `JavaScript`, `Next Js`, `Tailwind CSS`, `Go (Golang)`, `TypeScript`, `Docker`, `Kubernetes`, and `Final Cut Pro` with updated percentage values and sequential `id`s.  
- Updated `src/layout/Sidebar.js` to display a fixed copyright year `© 2026 Mamdouh` instead of using `new Date().getFullYear()`.  

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the project compiled client and server successfully.  
- Ran a Playwright script that navigated to `http://localhost:3000` and captured a screenshot `artifacts/sidebar-copyright-2026.png`, which completed successfully.  
- No unit or integration test suites were executed for these content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953edba7d9c832c89e7f5c0e99af445)