### PR TITLE
Guard client-side portfolio setup and Apollo endpoint

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,18 @@
 import TokyoState from "@/src/Context";
 import PreLoader from "@/src/layout/PreLoader";
 import "@/styles/globals.css";
-import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+} from "@apollo/client";
+
+const graphqlEndpoint =
+  process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL_ENDPOINT || "/api/graphql";
 
 // Create an Apollo Client instance
 const client = new ApolloClient({
-  uri: process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL_ENDPOINT,
+  uri: graphqlEndpoint,
   cache: new InMemoryCache(),
 });
 

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -137,15 +137,15 @@ const Portfolio = () => {
           <div className="list_wrapper w-full h-auto clear-both float-left">
             <ul className="portfolio_list gallery_zoom ml-[-40px] list-none">
               {projects.map((project, index) => {
-                const rawSection = project.projects.section || [
-                  "Uncategorized",
-                ];
+                const projectMeta = project.projects || {};
+                const rawSection = projectMeta.section || ["Uncategorized"];
                 const sectionsArray = Array.isArray(rawSection)
                   ? rawSection
                   : [rawSection];
                 const classNames = sectionsArray
                   .map((sec) => sec.replace(/\s+/g, ""))
                   .join(" ");
+                const dataCategory = projectMeta.subheading || "";
 
                 return (
                   <li
@@ -156,7 +156,7 @@ const Portfolio = () => {
                       <div
                         className="entry tokyo_tm_portfolio_animation_wrap"
                         data-title={project.title}
-                        data-category={project.projects.subheading}
+                        data-category={dataCategory}
                       >
                         <a
                           className="popup_info"

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,6 +42,10 @@ export const tokyo = {
       e = document.querySelector(".cursor-inner"),
       t = document.querySelector(".cursor-outer");
 
+    if (!e || !t) {
+      return;
+    }
+
     function mouseEvent(element) {
       element.addEventListener("mouseenter", function () {
         e.classList.add("cursor-hover"), t.classList.add("cursor-hover");
@@ -135,6 +139,12 @@ export const tokyo = {
       tokyo_tm_portfolio_titles = document.querySelector(
         ".tokyo_tm_portfolio_titles"
       );
+    if (
+      !tokyo_tm_portfolio_titles ||
+      tokyo_tm_portfolio_animation_wrap.length === 0
+    ) {
+      return;
+    }
     tokyo_tm_portfolio_animation_wrap.forEach((element) => {
       element.addEventListener("mousemove", () => {
         let title = element.getAttribute("data-title"),


### PR DESCRIPTION
### Motivation
- Prevent client-side exceptions caused by missing DOM elements used by the custom cursor and portfolio hover code.
- Avoid runtime crashes when the GraphQL endpoint environment variable is not provided.
- Harden portfolio rendering when project metadata may be absent or malformed.

### Description
- Default the Apollo `uri` to `process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL_ENDPOINT || "/api/graphql"` in `pages/_app.js` so the app does not crash when the env var is missing.
- Add null/length guards in `src/utils.js` to return early when cursor DOM nodes or portfolio title/wrap elements are not present, preventing client-side errors in SSR or non-DOM contexts.
- Defensively read project metadata in `src/components/Portfolio.js` by using `const projectMeta = project.projects || {}` and defaulting `section`/`subheading` values to avoid undefined access during mapping.
- Minor import formatting cleanup in `pages/_app.js` for consistency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552f153a04832c8c53fc0519f37465)