### PR TITLE
Guard DOM helpers against missing elements

### DIFF
--- a/src/useClickOutside.js
+++ b/src/useClickOutside.js
@@ -5,7 +5,7 @@ let useClickOutside = (handler) => {
 
   useEffect(() => {
     let maybeHandler = (event) => {
-      if (!domNode.current.contains(event.target)) {
+      if (!domNode.current || !domNode.current.contains(event.target)) {
         handler();
       }
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,9 @@ export const tokyo = {
           const parser = new DOMParser();
           const xmlDoc = parser.parseFromString(response, "text/html");
           let svg = xmlDoc.querySelector("svg");
+          if (!svg) {
+            return;
+          }
           if (typeof imgID !== "undefined") {
             svg.setAttribute("id", imgID);
           }


### PR DESCRIPTION
### Motivation
- Prevent client-side exceptions caused by DOM helper code that assumes certain elements always exist during runtime.
- Avoid crashes when SVG replacement fails because fetched content doesn't include an `<svg>` element.
- Make the click-outside hook resilient to cases where the ref has not yet been assigned (such as during SSR or initial render).

### Description
- Add a presence check in `tokyo.imageToSvg()` to `return` early when the fetched content does not contain an `svg` node. 
- Make `useClickOutside` robust by checking `domNode.current` before calling `contains` in the `maybeHandler` function. 
- Changes are limited to `src/utils.js` and `src/useClickOutside.js` and keep existing behavior when elements are present.

### Testing
- No automated tests were run for this change.
- Changes were kept minimal to reduce risk and rely on runtime guards to prevent the previously observed client-side exception.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553c86f920832ca5d1c00a3ce39bf3)