### PR TITLE
Pin Netlify Node to 20 and harden Portfolio components against missing projects/images

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[build.environment]
+  NODE_VERSION = "20"

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -86,7 +86,8 @@ const Portfolio = () => {
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error loading projects</p>;
 
-  const projects = data.projects.nodes;
+  const projects = (data?.projects?.nodes ?? []).filter(Boolean);
+  const fallbackImageUrl = "assets/img/thumbs/1-1.jpg";
 
   return (
     <SectionContainer name={"portfolio"}>
@@ -137,7 +138,7 @@ const Portfolio = () => {
           <div className="list_wrapper w-full h-auto clear-both float-left">
             <ul className="portfolio_list gallery_zoom ml-[-40px] list-none">
               {projects.map((project, index) => {
-                const projectMeta = project.projects || {};
+                const projectMeta = project?.projects || {};
                 const rawSection = projectMeta.section || ["Uncategorized"];
                 const sectionsArray = Array.isArray(rawSection)
                   ? rawSection
@@ -146,6 +147,9 @@ const Portfolio = () => {
                   .map((sec) => sec.replace(/\s+/g, ""))
                   .join(" ");
                 const dataCategory = projectMeta.subheading || "";
+                const featuredImageUrl =
+                  project?.featuredImage?.node?.sourceUrl || fallbackImageUrl;
+                const projectTitle = project?.title || "";
 
                 return (
                   <li
@@ -155,7 +159,7 @@ const Portfolio = () => {
                     <div className="inner w-full h-auto clear-both float-left overflow-hidden relative">
                       <div
                         className="entry tokyo_tm_portfolio_animation_wrap"
-                        data-title={project.title}
+                        data-title={projectTitle}
                         data-category={dataCategory}
                       >
                         <a
@@ -163,18 +167,20 @@ const Portfolio = () => {
                           href="#"
                           onClick={(e) => {
                             e.preventDefault();
-                            setPortfolioDetailsModal(project);
+                            if (project) {
+                              setPortfolioDetailsModal(project);
+                            }
                             modalToggle(true);
                           }}
                         >
                           <img
                             className="opacity-0 min-w-full"
                             src="assets/img/thumbs/1-1.jpg"
-                            alt={project.title}
+                            alt={projectTitle}
                           />
                           <div
                             className="abs_image absolute inset-0 bg-no-repeat bg-cover bg-center transition-all duration-300"
-                            data-img-url={project.featuredImage.node.sourceUrl}
+                            data-img-url={featuredImageUrl}
                           />
                         </a>
                       </div>

--- a/src/components/popup/DetailsModal.js
+++ b/src/components/popup/DetailsModal.js
@@ -20,7 +20,7 @@ const DetailsModal = () => {
   if (social3) socialLinks.push(social3);
 
   const mainImageUrl =
-    projects.headImage?.node?.sourceUrl || "assets/img/thumbs/4-2.jpg";
+    projects?.headImage?.node?.sourceUrl || "assets/img/thumbs/4-2.jpg";
   //format the date
   const formattedDate = date ? date.substring(0, 10) : "";
   console.log(mainImageUrl);


### PR DESCRIPTION
### Motivation
- Ensure consistent Netlify builds by pinning the Node version to `20` in build config.  
- Prevent client-side exceptions and blank UI when GraphQL returns missing or null `project` or image nodes.  
- Make the portfolio grid and details modal robust to absent featured/head images and missing project meta.

### Description
- Add `netlify.toml` with `command = "npm run build"`, `publish = ".next"`, and `NODE_VERSION = "20"` to pin the Netlify build environment.  
- In `Portfolio.js` filter falsy nodes with `(data?.projects?.nodes ?? []).filter(Boolean)`, add a `fallbackImageUrl`, compute `featuredImageUrl`, use optional chaining for project fields, and guard `setPortfolioDetailsModal` before calling it.  
- In `DetailsModal.js` use `projects?.headImage?.node?.sourceUrl` with a fallback image for `mainImageUrl` to avoid null dereferences.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695571a565a4832cb6c7757736637bb9)